### PR TITLE
Formatting markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # JSON to Python Types
+
 *json2pyi* infers a type schema from a sample JSON file and generates Python type definitions ([`dataclass`](https://docs.python.org/3/library/dataclasses.html), Pydantic [`BaseModel`](https://pydantic-docs.helpmanual.io/usage/models/) or PEP-589 [`TypedDict`](https://www.python.org/dev/peps/pep-0589/)) accordingly. It runs in browser, requiring no installation.
 
 <!--Even though the project is still an MVP, it is expected to be stable & usable as a Web app. Please do not hesitate to raise an issue if you find any problems.-->
 
-__Available online__: https://json2pyi.pages.dev
+__Available online__: <https://json2pyi.pages.dev>
 
 ## Example
+
 **Input:**
-```json
+
+```jsonc
 {
     "page": {
         "id": "kctbh9vrtdwd",
@@ -44,6 +47,7 @@ __Available online__: https://json2pyi.pages.dev
 ```
 
 **Output:**
+
 ```python
 @dataclass
 class Page:
@@ -105,28 +109,31 @@ RootObject = TypedDict("UnnammedType3C2BC8", {"page": Page, "status": Status, "c
 ```
 
 ## TODO
+
 - [ ] Detect tuple (array)
 - [x] Detect UUID / datetime
 - [ ] Detect Enum
 - [x] Merge data types with similar structure and common name prefix/suffix
-- [x] Detect recursive type definition (e.g. tree) 
+- [x] Detect recursive type definition (e.g. tree)
 - [x] Include imports of non-primitive types
 - [x] Generate type alias for complex Union
 - [ ] Improve the logic of determining whether a Union ix complex or not
 - [x] Generate TypedDict
-- [x] <del>Refactor to unify TypedDict and dataclass generation</del> Seperated intendedly for clear code structure.
+- [x] ~~Refactor to unify TypedDict and dataclass generation~~ Seperated intendedly for clear code structure.
 - [x] Compile to WASM and provide a Web-based app
-- [ ] Allow to tweak more options on Web app (partially blocked by https://github.com/vhiribarren/raytracer-rust/issues/8) 
+- [ ] Allow to tweak more options on Web app (partially blocked by <https://github.com/vhiribarren/raytracer-rust/issues/8>)
 - [ ] Avoid merging data types with totally different structures in a union
-- [ ] Avoid unnecessary heap allocation by reducing one-time usage of Vec 
-- [ ] Allow specifying the order of generated data types 
+- [ ] Avoid unnecessary heap allocation by reducing one-time usage of Vec
+- [ ] Allow specifying the order of generated data types
 - [ ] Support more input types, such as JSON Schema
 - [ ] Support more target languages
 - [ ] Add usage instructions
 
 ## Credits
-The project is inspired by: 
-- https://app.quicktype.io/?l=ts
-- https://github.com/thautwarm/schema-provider.py
-- https://jvilk.com/MakeTypes/
-- https://github.com/koxudaxi/datamodel-code-generator/
+
+The project is inspired by:
+
+- <https://app.quicktype.io/?l=ts>
+- <https://github.com/thautwarm/schema-provider.py>
+- <https://jvilk.com/MakeTypes/>
+- <https://github.com/koxudaxi/datamodel-code-generator/>


### PR DESCRIPTION
Guaranteeing the Markdown syntax specification will help the parsing consistency of different platforms.

- Removed trailing spaces.
- Avoided bare URL
- Converted inline HTML to Markdown.
- Syntax: `json` -> `jsonc` (JSON with comments).
- Headings should be surrounded by blank lines.